### PR TITLE
Added a date prop to FormatDate and RelativeTime

### DIFF
--- a/project/ShoelaceGenerator.scala
+++ b/project/ShoelaceGenerator.scala
@@ -71,6 +71,7 @@ class ShoelaceGenerator(
       case "String" => "stringProp"
       case "Int" => "intProp"
       case "Double" => "doubleProp"
+      case "js.Date | String" => "dateProp"
       case "dom.MutationObserver" | "js.Array[js.Object]" => "asIsProp"
       case _ =>
         println(s"PROP ...No impl defined for scala type `${scalaTypeStr}`, trying `htmlProp` for now.")

--- a/project/ShoelaceGenerator.scala
+++ b/project/ShoelaceGenerator.scala
@@ -71,7 +71,7 @@ class ShoelaceGenerator(
       case "String" => "stringProp"
       case "Int" => "intProp"
       case "Double" => "doubleProp"
-      case "js.Date | String" => "dateProp"
+      case "js.Date | String" => "asIsProp"
       case "dom.MutationObserver" | "js.Array[js.Object]" => "asIsProp"
       case _ =>
         println(s"PROP ...No impl defined for scala type `${scalaTypeStr}`, trying `htmlProp` for now.")

--- a/project/ShoelaceTranslator.scala
+++ b/project/ShoelaceTranslator.scala
@@ -135,7 +135,6 @@ class ShoelaceTranslator(
     (tagName, propName, jsTypes) match {
       // #nc #nc #nc vvvvvv TODO
       case ("sl-color-picker", "swatches", _) => true // Composite List[String] separated by ; IF used as an attribute. Property is an array, but not reflected.
-      case ("sl-format-date" | "sl-relative-time", "date", _) => true // Date | String - convert date with `date.toISOString()` - For MVP, just make an attribute, and a codec for date?
       // case ("sl-select", "value" | "defaultValue", _) => true // String | String[]. Space-delimited string in html attr. Use `value` vs `values`?
       // #nc #nc #nc ^^^^^ TODO
       // Don't want those props, we have (non-reflected) attributes for them.
@@ -594,7 +593,11 @@ class ShoelaceTranslator(
       //  println(s"WARNING: scalaAttrInputType: Multi-element input not supported for attr `${attr.attrName}` in tag `${tagName}`.")
       //  "Element" // #nc or Element[], but how to express that...
     } else {
-      throw new Exception(s"ERROR: scalaPropInputTypeStr does not support multiple printable types in prop `${prop.propName}` in tag `${tagName}`: ${printableTypes.mkString(", ")}")
+      if (printableTypes.toSet == Set(Def.JsCustomType("Date"), Def.JsStringType)) {
+        "js.Date | String"
+      } else {
+        throw new Exception(s"ERROR: scalaPropInputTypeStr does not support multiple printable types in prop `${prop.propName}` in tag `${tagName}`: ${printableTypes.mkString(", ")}")
+      }
     }
   }
 
@@ -634,6 +637,7 @@ class ShoelaceTranslator(
       case Def.JsCustomType("MutationObserver") => "dom.MutationObserver"
       case Def.JsCustomType("MutationRecord[]") => "js.Array[dom.MutationRecord]"
       case Def.JsCustomType("ResizeObserverEntry[]") => "js.Array[dom.ResizeObserverEntry]"
+      case Def.JsCustomType("Date") => "js.Date"
       case Def.JsCustomType(t) if t.startsWith("Sl") =>
         if (t.endsWith("[]")) {
           "js.Array[" + t.substring(2, t.length - 2) + ".Ref]"

--- a/src/main/scala/com/raquo/laminar/shoelace/sl/CommonTypes.scala
+++ b/src/main/scala/com/raquo/laminar/shoelace/sl/CommonTypes.scala
@@ -44,8 +44,6 @@ trait CommonTypes {
 
   protected def asIsProp[V](name: String): HtmlProp[V, _] = L.htmlProp(name, AsIsCodec[V]())
 
-  protected def dateProp(name: String): HtmlProp[js.Date | String, _] = L.htmlProp(name, AsIsCodec[js.Date | String]())
-
   protected def boolAttr(name: String): HtmlAttr[Boolean] = {
     L.htmlAttr(name, BooleanAsAttrPresenceCodec)
   }

--- a/src/main/scala/com/raquo/laminar/shoelace/sl/CommonTypes.scala
+++ b/src/main/scala/com/raquo/laminar/shoelace/sl/CommonTypes.scala
@@ -9,6 +9,7 @@ import com.raquo.laminar.keys.DerivedStyleProp
 import com.raquo.laminar.modifiers.KeySetter
 import com.raquo.laminar.modifiers.KeySetter.StyleSetter
 import org.scalajs.dom
+import scala.scalajs.js
 
 trait CommonTypes {
 
@@ -32,7 +33,7 @@ trait CommonTypes {
   //private val stringAttrs = js.Dictionary[HtmlAttr[String]]()
 
   protected def eventProp[Ev <: dom.Event](name: String): EventProp[Ev] = L.eventProp(name)
-  
+
   protected def stringProp(name: String): HtmlProp[String, _] = L.htmlProp(name, StringAsIsCodec)
 
   protected def intProp(name: String): HtmlProp[Int, _] = L.htmlProp(name, IntAsIsCodec)
@@ -42,6 +43,8 @@ trait CommonTypes {
   protected def boolProp(name: String): HtmlProp[Boolean, _] = L.htmlProp(name, BooleanAsIsCodec)
 
   protected def asIsProp[V](name: String): HtmlProp[V, _] = L.htmlProp(name, AsIsCodec[V]())
+
+  protected def dateProp(name: String): HtmlProp[js.Date | String, _] = L.htmlProp(name, AsIsCodec[js.Date | String]())
 
   protected def boolAttr(name: String): HtmlAttr[Boolean] = {
     L.htmlAttr(name, BooleanAsAttrPresenceCodec)

--- a/src/main/scala/com/raquo/laminar/shoelace/sl/FormatDate.scala
+++ b/src/main/scala/com/raquo/laminar/shoelace/sl/FormatDate.scala
@@ -73,7 +73,7 @@ object FormatDate extends WebComponent("sl-format-date") {
     * recommended to use the ISO 8601 format to ensure timezones are handled correctly. To convert a date to this format
     * in JavaScript, use [`date.toISOString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString).
     */
-  lazy val date: HtmlProp[js.Date | String, _] = dateProp("date")
+  lazy val date: HtmlProp[js.Date | String, _] = asIsProp("date")
 
 
   // -- Slots --

--- a/src/main/scala/com/raquo/laminar/shoelace/sl/FormatDate.scala
+++ b/src/main/scala/com/raquo/laminar/shoelace/sl/FormatDate.scala
@@ -1,6 +1,6 @@
 package com.raquo.laminar.shoelace.sl
 
-import com.raquo.laminar.keys.{HtmlAttr}
+import com.raquo.laminar.keys.{HtmlProp, HtmlAttr}
 import com.raquo.laminar.api.L
 import org.scalajs.dom
 
@@ -68,6 +68,13 @@ object FormatDate extends WebComponent("sl-format-date") {
 
   // -- Props --
 
+  /**
+    * The date/time to format. If not set, the current date and time will be used. When passing a string, it's strongly
+    * recommended to use the ISO 8601 format to ensure timezones are handled correctly. To convert a date to this format
+    * in JavaScript, use [`date.toISOString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString).
+    */
+  lazy val date: HtmlProp[js.Date | String, _] = dateProp("date")
+
 
   // -- Slots --
 
@@ -87,6 +94,13 @@ object FormatDate extends WebComponent("sl-format-date") {
   // -- Element type -- 
 
   @js.native trait FormatDateComponent extends js.Object { this: dom.HTMLElement => 
+
+    /**
+      * The date/time to format. If not set, the current date and time will be used. When passing a string, it's strongly
+      * recommended to use the ISO 8601 format to ensure timezones are handled correctly. To convert a date to this format
+      * in JavaScript, use [`date.toISOString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString).
+      */
+    var date: js.Date | String
 
     /** The format for displaying the weekday. */
     var weekday: String

--- a/src/main/scala/com/raquo/laminar/shoelace/sl/RelativeTime.scala
+++ b/src/main/scala/com/raquo/laminar/shoelace/sl/RelativeTime.scala
@@ -1,6 +1,6 @@
 package com.raquo.laminar.shoelace.sl
 
-import com.raquo.laminar.keys.{HtmlAttr}
+import com.raquo.laminar.keys.{HtmlProp, HtmlAttr}
 import com.raquo.laminar.api.L
 import org.scalajs.dom
 
@@ -47,6 +47,13 @@ object RelativeTime extends WebComponent("sl-relative-time") {
 
   // -- Props --
 
+  /**
+    * The date from which to calculate time from. If not set, the current date and time will be used. When passing a
+    * string, it's strongly recommended to use the ISO 8601 format to ensure timezones are handled correctly. To convert
+    * a date to this format in JavaScript, use [`date.toISOString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString).
+    */
+  lazy val date: HtmlProp[js.Date | String, _] = dateProp("date")
+
 
   // -- Slots --
 
@@ -66,6 +73,13 @@ object RelativeTime extends WebComponent("sl-relative-time") {
   // -- Element type -- 
 
   @js.native trait RelativeTimeComponent extends js.Object { this: dom.HTMLElement => 
+
+    /**
+      * The date from which to calculate time from. If not set, the current date and time will be used. When passing a
+      * string, it's strongly recommended to use the ISO 8601 format to ensure timezones are handled correctly. To convert
+      * a date to this format in JavaScript, use [`date.toISOString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString).
+      */
+    var date: js.Date | String
 
     /** The formatting style to use. */
     var format: String

--- a/src/main/scala/com/raquo/laminar/shoelace/sl/RelativeTime.scala
+++ b/src/main/scala/com/raquo/laminar/shoelace/sl/RelativeTime.scala
@@ -52,7 +52,7 @@ object RelativeTime extends WebComponent("sl-relative-time") {
     * string, it's strongly recommended to use the ISO 8601 format to ensure timezones are handled correctly. To convert
     * a date to this format in JavaScript, use [`date.toISOString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString).
     */
-  lazy val date: HtmlProp[js.Date | String, _] = dateProp("date")
+  lazy val date: HtmlProp[js.Date | String, _] = asIsProp("date")
 
 
   // -- Slots --


### PR DESCRIPTION
Adds support for passing either a JavaScript date or a String to the Shoelace FormatDate and RelativeTime components as per Shoelace's custom-elements.json. Before, these components rendered times relative to when they were instantiated, with no way to set a date through Laminar. Now, any date can be specified.
Here's an example of the prop in action:
```scala
p("Using a js.Date, this should be, '3 days ago': ", sl.RelativeTime.of(
    _.date(new js.Date(js.Date.now() - (24*60*60*1000 * 3)))
))
p("Using a String, this should be, '7/27/2024': ", sl.FormatDate.of(
    _.date("2024-07-28T02:41:45.682Z")
))
```
I'd love to hear what you think of this approach to union types!